### PR TITLE
Additional interface data in NetBoxInventory plugin

### DIFF
--- a/nornir_netbox/plugins/inventory/netbox.py
+++ b/nornir_netbox/plugins/inventory/netbox.py
@@ -207,7 +207,7 @@ class NetBoxInventory2:
             hosts[host.name] = host
         return Inventory(hosts=hosts)
 
-    def get_interfaces(self, device):
+    def get_interfaces(self, device: Dict[str, Any]) -> Dict[str, Any]:
 
         url = f"{self.nb_url}/api/dcim/interfaces/?limit=0"
 

--- a/nornir_netbox/plugins/inventory/netbox.py
+++ b/nornir_netbox/plugins/inventory/netbox.py
@@ -210,11 +210,11 @@ class NetBoxInventory2:
     def get_interfaces(self, device):
 
         url = f"{self.nb_url}/api/dcim/interfaces/?limit=0"
-        
+
         interfaces: List[Dict[str, Any]] = []
 
         while url:
-            r = self.session.get(url, params={"device_id": device.id})
+            r = self.session.get(url, params={"device_id": device["id"]})
 
             if not r.status_code == 200:
                 raise ValueError(
@@ -228,15 +228,16 @@ class NetBoxInventory2:
 
         url = f"{self.nb_url}/api/ipam/ip-addresses/?limit=0&assigned_to_interface=true"
 
-        for interface in interfaces if interface.count_ipaddresses:
-            r = self.session.get(url, params={"interface_id": interface['id']})
+        for interface in interfaces:
+            if interface["count_ipaddresses"]:
+                r = self.session.get(url, params={"interface_id": interface["id"]})
 
-            if not r.status_code == 200:
-                raise ValueError(
-                    f"Failed to get IP addresses from NetBox instance {self.nb_url}"
-                )
-            
-            resp = r.json()
-            interface['ip_addresses'] = resp.get("results")
+                if not r.status_code == 200:
+                    raise ValueError(
+                        f"Failed to get IP addresses from NetBox instance {self.nb_url}"
+                    )
+
+                resp = r.json()
+                interface["ip_addresses"] = resp.get("results")
 
         return {iface["name"]: iface for iface in interfaces}

--- a/tests/test_netbox.py
+++ b/tests/test_netbox.py
@@ -41,7 +41,7 @@ class TestNBInventory(object):
         assert expected == inv.dict()
 
     def test_inventory_pagination(self, requests_mock):
-        inv = get_inv(requests_mock, self.plugin, False)
+        inv = get_inv(requests_mock, self.plugin, True)
         with open(f"{BASE_PATH}/{self.plugin.__name__}/expected.json", "r") as f:
             expected = json.load(f)
         assert expected == inv.dict()


### PR DESCRIPTION
Wondering if this could potentially be added to this repo.  This code handles conditionally pulling in interfaces and assigned IP addresses for each device in inventory.

Also, may see I noticed the logic to run both paginated and non-paginated wasn't set correctly and I fixed that I believe.

I can add tests as well but not super familiar with requests_mock so thought I would run this by you and made sure it would be accepted before adding tests.  Just let me know.  Thanks.