### PR TITLE
Add is_virtual attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Arguments:
     flatten_custom_fields: Assign custom fields directly to the host's data attribute
         (defaults to False)
     filter_parameters: Key-value pairs that allow you to filter the NetBox inventory.
-    include_vms: Get virtual machines from NetBox as well as devices.
+    include_vms: Get virtual machines from NetBox as well as devices. This will also `is_virtual` to the host's data attributes.
         (defaults to False)
     use_platform_slug: Use the NetBox platform slug for the platform attribute of a Host
         (defaults to False)

--- a/nornir_netbox/plugins/inventory/netbox.py
+++ b/nornir_netbox/plugins/inventory/netbox.py
@@ -242,12 +242,16 @@ class NetBoxInventory2:
         )
 
         if self.include_vms:
-            nb_devices.extend(
-                self._get_resources(
-                    url=f"{self.nb_url}/api/virtualization/virtual-machines/?limit=0",
-                    params=self.filter_parameters,
-                )
+            vms = self._get_resources(
+                url=f"{self.nb_url}/api/virtualization/virtual-machines/?limit=0",
+                params=self.filter_parameters,
             )
+            for vm in vms:
+                vm["is_virtual"] = True
+            for device in nb_devices:
+                device["is_virtual"] = False
+            nb_devices.extend(vms)
+
 
         hosts = Hosts()
         groups = Groups()

--- a/nornir_netbox/plugins/inventory/netbox.py
+++ b/nornir_netbox/plugins/inventory/netbox.py
@@ -252,7 +252,6 @@ class NetBoxInventory2:
                 device["is_virtual"] = False
             nb_devices.extend(vms)
 
-
         hosts = Hosts()
         groups = Groups()
         defaults = Defaults()

--- a/tests/NetBoxInventory2/2.8.9/vms-expected.json
+++ b/tests/NetBoxInventory2/2.8.9/vms-expected.json
@@ -69,7 +69,8 @@
           "comments": "",
           "custom_fields": {},
           "created": "2018-07-12",
-          "last_updated": "2018-07-12T11:53:54.742412Z"
+          "last_updated": "2018-07-12T11:53:54.742412Z",
+          "is_virtual": false
         },
         "hostname": "10.0.1.4",
         "port": null,
@@ -146,7 +147,8 @@
           "comments": "",
           "custom_fields": {},
           "created": "2018-07-12",
-          "last_updated": "2018-07-12T11:53:54.742412Z"
+          "last_updated": "2018-07-12T11:53:54.742412Z",
+          "is_virtual": false
         },
         "hostname": "10.0.1.1",
         "port": null,
@@ -218,7 +220,8 @@
           "comments": "",
           "custom_fields": {},
           "created": "2018-07-12",
-          "last_updated": "2018-07-12T11:53:54.802934Z"
+          "last_updated": "2018-07-12T11:53:54.802934Z",
+          "is_virtual": false
         },
         "hostname": "172.16.2.1",
         "port": null,
@@ -297,7 +300,8 @@
             "user_defined": 1
           },
           "created": "2018-07-12",
-          "last_updated": "2018-07-12T11:53:54.866133Z"
+          "last_updated": "2018-07-12T11:53:54.866133Z",
+          "is_virtual": false
         },
         "hostname": "192.168.3.1",
         "port": null,
@@ -372,7 +376,8 @@
             ]
           },
           "created": "2020-09-06",
-          "last_updated": "2020-09-06T05:03:17.932973Z"
+          "last_updated": "2020-09-06T05:03:17.932973Z",
+          "is_virtual": true
         },
         "hostname": "2.2.2.2",
         "port": null,
@@ -441,7 +446,8 @@
             "testbed": "abcd"
           },
           "created": "2020-09-06",
-          "last_updated": "2020-09-06T05:03:36.371611Z"
+          "last_updated": "2020-09-06T05:03:36.371611Z",
+          "is_virtual": true
         },
         "hostname": "55.1.0.3",
         "port": null,
@@ -519,7 +525,8 @@
             ]
           },
           "created": "2020-09-06",
-          "last_updated": "2020-09-06T05:03:52.392577Z"
+          "last_updated": "2020-09-06T05:03:52.392577Z",
+          "is_virtual": true
         },
         "hostname": "16.52.0.1",
         "port": null,
@@ -588,7 +595,8 @@
             "role": "prod"
           },
           "created": "2020-09-06",
-          "last_updated": "2020-09-06T05:03:03.629883Z"
+          "last_updated": "2020-09-06T05:03:03.629883Z",
+          "is_virtual": true
         },
         "hostname": "66.102.99.6",
         "port": null,

--- a/tests/NetBoxInventory2/2.8.9/vms-expected_use_platform_slug.json
+++ b/tests/NetBoxInventory2/2.8.9/vms-expected_use_platform_slug.json
@@ -69,7 +69,8 @@
           "comments": "",
           "custom_fields": {},
           "created": "2018-07-12",
-          "last_updated": "2018-07-12T11:53:54.742412Z"
+          "last_updated": "2018-07-12T11:53:54.742412Z",
+          "is_virtual": false
         },
         "hostname": "10.0.1.4",
         "port": null,
@@ -146,7 +147,8 @@
           "comments": "",
           "custom_fields": {},
           "created": "2018-07-12",
-          "last_updated": "2018-07-12T11:53:54.742412Z"
+          "last_updated": "2018-07-12T11:53:54.742412Z",
+          "is_virtual": false
         },
         "hostname": "10.0.1.1",
         "port": null,
@@ -218,7 +220,8 @@
           "comments": "",
           "custom_fields": {},
           "created": "2018-07-12",
-          "last_updated": "2018-07-12T11:53:54.802934Z"
+          "last_updated": "2018-07-12T11:53:54.802934Z",
+          "is_virtual": false
         },
         "hostname": "172.16.2.1",
         "port": null,
@@ -297,7 +300,8 @@
             "user_defined": 1
           },
           "created": "2018-07-12",
-          "last_updated": "2018-07-12T11:53:54.866133Z"
+          "last_updated": "2018-07-12T11:53:54.866133Z",
+          "is_virtual": false
         },
         "hostname": "192.168.3.1",
         "port": null,
@@ -372,7 +376,8 @@
             ]
           },
           "created": "2020-09-06",
-          "last_updated": "2020-09-06T05:03:17.932973Z"
+          "last_updated": "2020-09-06T05:03:17.932973Z",
+          "is_virtual": true
         },
         "hostname": "2.2.2.2",
         "port": null,
@@ -441,7 +446,8 @@
             "testbed": "abcd"
           },
           "created": "2020-09-06",
-          "last_updated": "2020-09-06T05:03:36.371611Z"
+          "last_updated": "2020-09-06T05:03:36.371611Z",
+          "is_virtual": true
         },
         "hostname": "55.1.0.3",
         "port": null,
@@ -519,7 +525,8 @@
             ]
           },
           "created": "2020-09-06",
-          "last_updated": "2020-09-06T05:03:52.392577Z"
+          "last_updated": "2020-09-06T05:03:52.392577Z",
+          "is_virtual": true
         },
         "hostname": "16.52.0.1",
         "port": null,
@@ -588,7 +595,8 @@
             "role": "prod"
           },
           "created": "2020-09-06",
-          "last_updated": "2020-09-06T05:03:03.629883Z"
+          "last_updated": "2020-09-06T05:03:03.629883Z",
+          "is_virtual": true
         },
         "hostname": "66.102.99.6",
         "port": null,


### PR DESCRIPTION
This PR adds the `is_virtual` attribute to the host's data attributes to differentiate between VMs and devices.