### PR TITLE
Handle PermissionError when looking for the defaults or groups files

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -248,3 +248,13 @@ More information on on the groups file can be found in [Nornir's documentation](
 | type     | str          |
 | default  | "groups.yaml |
 | required | False        |
+
+### Ignore file permission errors
+
+Ignore file defaults or group file permission errors. Enabling this option will continue loading the inventory when file permission errors are encountered for the defaults or group file.
+
+| name     | ignore\_file\_permission\_errors |
+|----------|----------------------|
+| type     | bool                 |
+| default  | False                |
+| required | False                |

--- a/tests/test_netbox.py
+++ b/tests/test_netbox.py
@@ -1,6 +1,7 @@
 import json
 import os
 
+from pathlib import Path
 from typing import Any
 from typing import Type
 from typing import Union
@@ -345,6 +346,128 @@ class TestNetBoxInventory2(BaseTestInventory):
             version,
             defaults_file=f"{BASE_PATH}/data/defaults-empty.yaml",
             groups_file=f"{BASE_PATH}/data/groups-empty.yaml",
+        )
+
+        with open(
+            f"{BASE_PATH}/{self.plugin.__name__}/{version}/expected.json", "r"
+        ) as f:
+            expected = json.load(f)
+
+        assert expected == inv.dict()
+
+    @pytest.mark.parametrize("version", VERSIONS)
+    def test_inventory_with_defaults_file_permission_error_raises_exception(
+        self, tmp_path: Path, requests_mock: Mocker, version: str
+    ) -> None:
+        "test loading inventory with defaults file with bad permissions, should raise an exception"
+
+        defaults_file = tmp_path / "defaults-000.yaml"
+        defaults_file.touch(mode=0, exist_ok=True)
+
+        with pytest.raises(PermissionError):
+            get_inv(
+                requests_mock,
+                self.plugin,
+                False,
+                version,
+                defaults_file=defaults_file,
+                group_file=f"{BASE_PATH}/data/group.yaml",
+            )
+
+    @pytest.mark.parametrize("version", VERSIONS)
+    def test_inventory_with_group_file_permission_error_raises_exception(
+        self, tmp_path: Path, requests_mock: Mocker, version: str
+    ) -> None:
+        "test loading inventory with group file that has bad permissions, should raise an exception"
+
+        group_file = tmp_path / "group-000.yaml"
+        group_file.touch(mode=0, exist_ok=True)
+
+        with pytest.raises(PermissionError):
+            get_inv(
+                requests_mock,
+                self.plugin,
+                False,
+                version,
+                defaults_file=f"{BASE_PATH}/data/defaults.yaml",
+                group_file=group_file,
+            )
+
+    @pytest.mark.parametrize("version", VERSIONS)
+    def test_inventory_with_defaults_file_ignore_permission_error(
+        self, tmp_path: Path, requests_mock: Mocker, version: str
+    ) -> None:
+        """test loading inventory with defaults file with bad permissions,
+        should not raise an exception
+        """
+
+        defaults_file = tmp_path / "defaults-000.yaml"
+        defaults_file.touch(mode=0, exist_ok=True)
+
+        with open(
+            f"{BASE_PATH}/{self.plugin.__name__}/{version}/expected.json", "r"
+        ) as f:
+            expected = json.load(f)
+
+        inv = get_inv(
+            requests_mock,
+            self.plugin,
+            False,
+            version,
+            defaults_file=defaults_file,
+            group_file=f"{BASE_PATH}/data/group.yaml",
+            ignore_file_permission_errors=True,
+        )
+
+        assert inv.dict() == expected
+
+    @pytest.mark.parametrize("version", VERSIONS)
+    def test_inventory_with_group_file_ignore_permission_error(
+        self, tmp_path: Path, requests_mock: Mocker, version: str
+    ) -> None:
+        "test loading inventory with group file with bad permissions, should not raise an exception"
+
+        group_file = tmp_path / "group-000.yaml"
+        group_file.touch(mode=0, exist_ok=True)
+
+        with open(
+            f"{BASE_PATH}/{self.plugin.__name__}/{version}/expected-defaults.json", "r"
+        ) as f:
+            expected = json.load(f)
+
+        inv = get_inv(
+            requests_mock,
+            self.plugin,
+            False,
+            version,
+            group_file=group_file,
+            defaults_file=f"{BASE_PATH}/data/defaults.yaml",
+            ignore_file_permission_errors=True,
+        )
+
+        assert inv.dict() == expected
+
+    @pytest.mark.parametrize("version", VERSIONS)
+    def test_inventory_with_ignore_file_errors_and_bad_permissions_on_files(
+        self, tmp_path: Path, requests_mock: Mocker, version: str
+    ) -> None:
+        "test loading inventory with bad permissions on both the defaults and groups file with"
+        "ignore_file_errors, should not raise an exception"
+
+        # Set the permissions on the files
+        defaults_file = tmp_path / "defaults-000.yaml"
+        defaults_file.touch(mode=0, exist_ok=True)
+        group_file = tmp_path / "group-000.yaml"
+        group_file.touch(mode=0, exist_ok=True)
+
+        inv = get_inv(
+            requests_mock,
+            self.plugin,
+            False,
+            version,
+            ignore_file_permission_errors=True,
+            defaults_file=defaults_file,
+            group_file=group_file,
         )
 
         with open(


### PR DESCRIPTION
When checking if the `defaults` or `groups` files exist, it can throw a permissions error. This can happen when running a script with sudo as a different user that doesn't have permission to the current working directory.